### PR TITLE
Use custom tun open implemention

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,8 +59,8 @@ type FallbackFilter struct {
 
 // Tun config
 type Tun struct {
-	Enable      bool   `yaml:"enable" json:"enable"`
-	LinuxIfName string `yaml:"linux-if-name" json:"linux-if-name"`
+	Enable    bool   `yaml:"enable" json:"enable"`
+	DeviceURL string `yaml:"device-url" json:"device-url"`
 }
 
 // Experimental config
@@ -162,8 +162,8 @@ func readConfig(path string) (*rawConfig, error) {
 		Proxy:          []map[string]interface{}{},
 		ProxyGroup:     []map[string]interface{}{},
 		Tun: Tun{
-			Enable:      false,
-			LinuxIfName: "clash0",
+			Enable:    false,
+			DeviceURL: "dev://clash0",
 		},
 		Experimental: Experimental{
 			IgnoreResolveFail: true,

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -130,7 +130,7 @@ func updateGeneral(general *config.General) {
 		log.Errorln("Start Redir server error: %s", err.Error())
 	}
 
-	if err := P.ReCreateTun(general.Tun.Enable, general.Tun.LinuxIfName); err != nil {
+	if err := P.ReCreateTun(general.Tun.Enable, general.Tun.DeviceURL); err != nil {
 		log.Errorln("Start Tun interface error: %s", err.Error())
 	}
 

--- a/hub/route/configs.go
+++ b/hub/route/configs.go
@@ -67,7 +67,7 @@ func patchConfigs(w http.ResponseWriter, r *http.Request) {
 	P.ReCreateSocks(pointerOrDefault(general.SocksPort, ports.SocksPort))
 	P.ReCreateRedir(pointerOrDefault(general.RedirPort, ports.RedirPort))
 	if general.Tun != nil {
-		P.ReCreateTun(general.Tun.Enable, general.Tun.LinuxIfName)
+		P.ReCreateTun(general.Tun.Enable, general.Tun.DeviceURL)
 	}
 
 	if general.Mode != nil {

--- a/proxy/listener.go
+++ b/proxy/listener.go
@@ -51,8 +51,8 @@ func Tun() config.Tun {
 		return config.Tun{}
 	}
 	return config.Tun{
-		Enable:      true,
-		LinuxIfName: tunAdapter.IfName(),
+		Enable:    true,
+		DeviceURL: tunAdapter.DeviceURL(),
 	}
 }
 
@@ -157,9 +157,9 @@ func ReCreateRedir(port int) error {
 	return nil
 }
 
-func ReCreateTun(enable bool, ifname string) error {
+func ReCreateTun(enable bool, url string) error {
 	if tunAdapter != nil {
-		if enable && (ifname == "" || ifname == tunAdapter.IfName()) {
+		if enable && (url == "" || url == tunAdapter.DeviceURL()) {
 			return nil
 		}
 		tunAdapter.Close()
@@ -169,7 +169,7 @@ func ReCreateTun(enable bool, ifname string) error {
 		return nil
 	}
 	var err error
-	tunAdapter, err = tun.NewTunProxy(ifname)
+	tunAdapter, err = tun.NewTunProxy(url)
 	return err
 }
 

--- a/proxy/tun/dev/dev.default.go
+++ b/proxy/tun/dev/dev.default.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux,!android
 
 package dev
 

--- a/proxy/tun/dev/dev.default.go
+++ b/proxy/tun/dev/dev.default.go
@@ -1,0 +1,14 @@
+// +build !linux
+
+package dev
+
+import (
+	"errors"
+	"runtime"
+
+	"net/url"
+)
+
+func OpenTunDevice(_ url.URL) (TunDevice, error) {
+	return nil, errors.New("Unsupported platform " + runtime.GOOS)
+}

--- a/proxy/tun/dev/dev.go
+++ b/proxy/tun/dev/dev.go
@@ -1,0 +1,9 @@
+package dev
+
+import "github.com/google/netstack/tcpip/stack"
+
+type TunDevice interface {
+	Name() string
+	AsLinkEndpoint() (stack.LinkEndpoint, error)
+	Close()
+}

--- a/proxy/tun/dev/dev.go
+++ b/proxy/tun/dev/dev.go
@@ -3,7 +3,7 @@ package dev
 import "github.com/google/netstack/tcpip/stack"
 
 type TunDevice interface {
-	Name() string
+	URL() string
 	AsLinkEndpoint() (stack.LinkEndpoint, error)
 	Close()
 }

--- a/proxy/tun/dev/dev.go
+++ b/proxy/tun/dev/dev.go
@@ -3,6 +3,7 @@ package dev
 import "github.com/google/netstack/tcpip/stack"
 
 type TunDevice interface {
+	Name() string
 	URL() string
 	AsLinkEndpoint() (stack.LinkEndpoint, error)
 	Close()

--- a/proxy/tun/dev/dev.linux.go
+++ b/proxy/tun/dev/dev.linux.go
@@ -1,0 +1,150 @@
+// +build linux
+
+package dev
+
+import (
+	"errors"
+	"net/url"
+	"strconv"
+	"syscall"
+	"unsafe"
+
+	"github.com/google/netstack/tcpip/link/fdbased"
+	"github.com/google/netstack/tcpip/stack"
+)
+
+type tun struct {
+	name    string
+	fd      int
+	closeFd bool
+}
+
+func OpenTunDevice(deviceURL url.URL) (TunDevice, error) {
+	switch deviceURL.Scheme {
+	case "dev":
+		return openDeviceByName(deviceURL.Host)
+	case "fd":
+		fd, err := strconv.ParseInt(deviceURL.Host, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		return openDeviceByFd(int(fd))
+	}
+
+	return nil, errors.New("Unsupported device type " + deviceURL.Scheme)
+}
+
+func (t tun) Name() string {
+	return t.name
+}
+
+func (t tun) AsLinkEndpoint() (stack.LinkEndpoint, error) {
+	mtu, err := t.getInterfaceMtu()
+
+	if err != nil {
+		return nil, errors.New("Unable to get device mtu")
+	}
+
+	return fdbased.New(&fdbased.Options{
+		FDs:            []int{t.fd},
+		MTU:            mtu,
+		EthernetHeader: false,
+	})
+}
+
+func (t tun) Close() {
+	if t.closeFd {
+		syscall.Close(t.fd)
+	}
+}
+
+func openDeviceByName(name string) (TunDevice, error) {
+	fd, err := syscall.Open("/dev/net/tun", syscall.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var ifr struct {
+		name  [16]byte
+		flags uint16
+		_     [22]byte
+	}
+
+	copy(ifr.name[:], name)
+	ifr.flags = syscall.IFF_TUN | syscall.IFF_NO_PI
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), syscall.TUNSETIFF, uintptr(unsafe.Pointer(&ifr)))
+	if errno != 0 {
+		syscall.Close(fd)
+		return nil, errno
+	}
+
+	if err = syscall.SetNonblock(fd, true); err != nil {
+		syscall.Close(fd)
+		return nil, err
+	}
+
+	return &tun{
+		name:    convertInterfaceName(ifr.name),
+		fd:      fd,
+		closeFd: true,
+	}, nil
+}
+
+func openDeviceByFd(fd int) (TunDevice, error) {
+	var ifr struct {
+		name  [16]byte
+		flags uint16
+		_     [22]byte
+	}
+
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), syscall.TUNGETIFF, uintptr(unsafe.Pointer(&ifr)))
+	if errno != 0 {
+		return nil, errno
+	}
+
+	if ifr.flags&syscall.IFF_TUN == 0 || ifr.flags&syscall.IFF_NO_PI == 0 {
+		return nil, errors.New("Only tun device and no pi mode supported")
+	}
+
+	return &tun{
+		name:    convertInterfaceName(ifr.name),
+		fd:      fd,
+		closeFd: false,
+	}, nil
+}
+
+func (t tun) getInterfaceMtu() (uint32, error) {
+	fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_DGRAM, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	defer syscall.Close(fd)
+
+	var ifreq struct {
+		name [16]byte
+		mtu  int32
+		_    [20]byte
+	}
+
+	copy(ifreq.name[:], t.name)
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), syscall.SIOCGIFMTU, uintptr(unsafe.Pointer(&ifreq)))
+	if errno != 0 {
+		return 0, errno
+	}
+
+	return uint32(ifreq.mtu), nil
+}
+
+func convertInterfaceName(buf [16]byte) string {
+	var n int
+
+	for i, c := range buf {
+		if c == 0 {
+			n = i
+			break
+		}
+	}
+
+	return string(buf[:n])
+}

--- a/proxy/tun/dev/dev.linux.go
+++ b/proxy/tun/dev/dev.linux.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux android
 
 package dev
 

--- a/proxy/tun/dev/dev.linux.go
+++ b/proxy/tun/dev/dev.linux.go
@@ -41,6 +41,10 @@ func OpenTunDevice(deviceURL url.URL) (TunDevice, error) {
 	return nil, errors.New("Unsupported device type " + deviceURL.Scheme)
 }
 
+func (t tun) Name() string {
+	return t.name
+}
+
 func (t tun) URL() string {
 	return t.url
 }

--- a/proxy/tun/tun.go
+++ b/proxy/tun/tun.go
@@ -110,7 +110,7 @@ func NewTunProxy(deviceURL string) (*TunAdapter, error) {
 		device:  tundev,
 		ipstack: ipstack,
 	}
-	log.Infoln("Tun device opened by %s", tundev.URL())
+	log.Infoln("Tun adapter have interface name: %s", tundev.Name())
 
 	return tl, nil
 

--- a/proxy/tun/tun.go
+++ b/proxy/tun/tun.go
@@ -43,7 +43,7 @@ func NewTunProxy(deviceURL string) (*TunAdapter, error) {
 
 	url, err := url.Parse(deviceURL)
 	if err != nil {
-		return nil, fmt.Errorf("Can't open tun: %v", err)
+		return nil, fmt.Errorf("Invalid tun device url: %v", err)
 	}
 
 	tundev, err := dev.OpenTunDevice(*url)

--- a/proxy/tun/tun.go
+++ b/proxy/tun/tun.go
@@ -58,7 +58,7 @@ func NewTunProxy(deviceURL string) (*TunAdapter, error) {
 
 	linkEP, err := tundev.AsLinkEndpoint()
 	if err != nil {
-		return nil, fmt.Errorf("Unablt to create virtual endpoint", err)
+		return nil, fmt.Errorf("Unable to create virtual endpoint: %v", err)
 	}
 
 	if err := ipstack.CreateNIC(1, linkEP); err != nil {

--- a/proxy/tun/tun.go
+++ b/proxy/tun/tun.go
@@ -110,7 +110,7 @@ func NewTunProxy(deviceURL string) (*TunAdapter, error) {
 		device:  tundev,
 		ipstack: ipstack,
 	}
-	log.Infoln("Tun adapter have interface name: %s", tundev.Name())
+	log.Infoln("Tun device opened by %s", tundev.URL())
 
 	return tl, nil
 
@@ -122,9 +122,9 @@ func (t *TunAdapter) Close() {
 	ipstack.Close()
 }
 
-// IfName return the NIC name of tun
-func (t *TunAdapter) IfName() string {
-	return t.device.Name()
+// IfName return device URL of tun
+func (t *TunAdapter) DeviceURL() string {
+	return t.device.URL()
 }
 
 func getAddr(id stack.TransportEndpointID) socks5.Addr {

--- a/proxy/tun/tun.go
+++ b/proxy/tun/tun.go
@@ -3,22 +3,20 @@ package tun
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"strings"
-	"syscall"
 
 	adapters "github.com/Dreamacro/clash/adapters/inbound"
 	"github.com/Dreamacro/clash/component/socks5"
 	C "github.com/Dreamacro/clash/constant"
 	"github.com/Dreamacro/clash/log"
+	"github.com/Dreamacro/clash/proxy/tun/dev"
 	"github.com/Dreamacro/clash/tunnel"
 
 	"encoding/binary"
 
 	"github.com/google/netstack/tcpip"
 	"github.com/google/netstack/tcpip/adapters/gonet"
-	"github.com/google/netstack/tcpip/link/fdbased"
-	"github.com/google/netstack/tcpip/link/rawfile"
-	netstacktun "github.com/google/netstack/tcpip/link/tun"
 	"github.com/google/netstack/tcpip/network/ipv4"
 	"github.com/google/netstack/tcpip/network/ipv6"
 	"github.com/google/netstack/tcpip/stack"
@@ -34,20 +32,23 @@ var (
 
 // TunAdapter is the wraper of tun
 type TunAdapter struct {
-	tunfd   int
+	device  dev.TunDevice
 	ipstack *stack.Stack
-	ifName  string
 }
 
 // NewTunProxy create TunProxy under Linux OS.
-func NewTunProxy(linuxIfName string) (*TunAdapter, error) {
+func NewTunProxy(deviceURL string) (*TunAdapter, error) {
 
 	var err error
-	tunfd, err := netstacktun.Open(linuxIfName)
 
+	url, err := url.Parse(deviceURL)
 	if err != nil {
 		return nil, fmt.Errorf("Can't open tun: %v", err)
+	}
 
+	tundev, err := dev.OpenTunDevice(*url)
+	if err != nil {
+		return nil, fmt.Errorf("Can't open tun: %v", err)
 	}
 
 	ipstack = stack.New(stack.Options{
@@ -55,20 +56,13 @@ func NewTunProxy(linuxIfName string) (*TunAdapter, error) {
 		TransportProtocols: []stack.TransportProtocol{tcp.NewProtocol(), udp.NewProtocol()},
 	})
 
-	mtu, err := rawfile.GetMTU(linuxIfName)
+	linkEP, err := tundev.AsLinkEndpoint()
 	if err != nil {
-		return nil, fmt.Errorf("Can't get MTU from tun: %v", err)
+		return nil, fmt.Errorf("Unablt to create virtual endpoint", err)
 	}
-
-	linkEP, err := fdbased.New(&fdbased.Options{
-		FDs:            []int{tunfd},
-		MTU:            mtu,
-		EthernetHeader: false,
-	})
 
 	if err := ipstack.CreateNIC(1, linkEP); err != nil {
 		return nil, fmt.Errorf("Fail to create NIC in ipstack: %v", err)
-
 	}
 
 	// IPv4 0.0.0.0/0
@@ -85,6 +79,7 @@ func NewTunProxy(linuxIfName string) (*TunAdapter, error) {
 		ep, err := r.CreateEndpoint(&wq)
 		if err != nil {
 			log.Warnln("Can't create TCP Endpoint in ipstack: %v", err)
+			return
 		}
 		r.Complete(false)
 
@@ -113,11 +108,10 @@ func NewTunProxy(linuxIfName string) (*TunAdapter, error) {
 	ipstack.SetTransportProtocolHandler(udp.ProtocolNumber, udpFwd.HandlePacket)
 
 	tl := &TunAdapter{
-		tunfd:   tunfd,
+		device:  tundev,
 		ipstack: ipstack,
-		ifName:  linuxIfName,
 	}
-	log.Infoln("Tun adapter have interface name: %s", linuxIfName)
+	log.Infoln("Tun adapter have interface name: %s", tundev.Name())
 
 	return tl, nil
 
@@ -125,18 +119,12 @@ func NewTunProxy(linuxIfName string) (*TunAdapter, error) {
 
 // Close close the TunAdapter
 func (t *TunAdapter) Close() {
-	if t.tunfd != -1 {
-		syscall.Close(t.tunfd)
-		t.tunfd = -1
-	}
+	t.device.Close()
 }
 
 // IfName return the NIC name of tun
 func (t *TunAdapter) IfName() string {
-	if t.tunfd != -1 {
-		return t.ifName
-	}
-	return ""
+	return t.device.Name()
 }
 
 func getAddr(id stack.TransportEndpointID) socks5.Addr {


### PR DESCRIPTION
Use custom tun open implemention

Changed
* Describe tun device by URL
  Open tun device by name `dev://<device-name>`
  Open tun device by file description `fd://<fd>`
* Build on Windows/MacOS (But tun still not working)
  `Unsupported platform ${runtime.GOOS}`

Example config
```yaml
socks-port: 1080
tun:
  enable: true
  device-url: dev://clash0
```