### PR TITLE
support auto reopen when tun device is deleted and re-added

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,9 +76,10 @@ type FallbackFilter struct {
 
 // Tun config
 type Tun struct {
-	Enable    bool   `yaml:"enable" json:"enable"`
-	DeviceURL string `yaml:"device-url" json:"device-url"`
-	DNSListen string `yaml:"dns-listen" json:"dns-listen"`
+	Enable     bool   `yaml:"enable" json:"enable"`
+	DeviceURL  string `yaml:"device-url" json:"device-url"`
+	DNSListen  string `yaml:"dns-listen" json:"dns-listen"`
+	AutoReopen bool   `yaml:"auto-reopen" json:"auto-reopen"`
 }
 
 // Experimental config

--- a/proxy/listener.go
+++ b/proxy/listener.go
@@ -303,7 +303,7 @@ func ReCreateTun(conf config.Tun) error {
 		return nil
 	}
 	var err error
-	tunAdapter, err = tun.NewTunProxy(url)
+	tunAdapter, err = tun.NewTunProxy(url, conf.AutoReopen)
 	if err != nil {
 		return err
 	}

--- a/proxy/tun/dev/dev_darwin.go
+++ b/proxy/tun/dev/dev_darwin.go
@@ -92,11 +92,16 @@ type ifreqAddr struct {
 var sockaddrCtlSize uintptr = 32
 
 // OpenTunDevice return a TunDevice according a URL
-func OpenTunDevice(deviceURL url.URL) (TunDevice, error) {
+func OpenTunDevice(deviceURL url.URL, autoReopen bool) (TunDevice, error) {
 	if deviceURL.Scheme != "dev" {
 		return nil, errors.New("unsupported device type " + deviceURL.Scheme)
 
 	}
+
+	if autoReopen {
+		return nil, errors.New("auto reopen feature is not supported on darwin yet.")
+	}
+
 	name := deviceURL.Host
 	// TODO: configure the MTU
 	mtu := 9000

--- a/proxy/tun/dev/dev_unsupport.go
+++ b/proxy/tun/dev/dev_unsupport.go
@@ -9,6 +9,6 @@ import (
 	"net/url"
 )
 
-func OpenTunDevice(_ url.URL) (TunDevice, error) {
+func OpenTunDevice(_ url.URL, autoReopen bool) (TunDevice, error) {
 	return nil, errors.New("Unsupported platform " + runtime.GOOS + "/" + runtime.GOARCH)
 }

--- a/proxy/tun/tunproxy.go
+++ b/proxy/tun/tunproxy.go
@@ -36,7 +36,7 @@ type tunAdapter struct {
 }
 
 // NewTunProxy create TunProxy under Linux OS.
-func NewTunProxy(deviceURL string) (TunAdapter, error) {
+func NewTunProxy(deviceURL string, autoReopen bool) (TunAdapter, error) {
 
 	var err error
 
@@ -45,7 +45,7 @@ func NewTunProxy(deviceURL string) (TunAdapter, error) {
 		return nil, fmt.Errorf("invalid tun device url: %v", err)
 	}
 
-	tundev, err := dev.OpenTunDevice(*url)
+	tundev, err := dev.OpenTunDevice(*url, autoReopen)
 	if err != nil {
 		return nil, fmt.Errorf("can't open tun: %v", err)
 	}


### PR DESCRIPTION
* current issue: have to restart the clash process if the tun file is deleted from system and re-added back later.
* autoReopen option is added to tun config and this option is by default off.
* the new code only supports Linux Tun yet.